### PR TITLE
Don't create /usr/lib/.build-id files

### DIFF
--- a/ldnp/rpm.py
+++ b/ldnp/rpm.py
@@ -122,6 +122,9 @@ class RpmPackager(AbstractPackager):
                 # better use a custom variable to make things explicit
                 "--define",
                 f"_install_root {self.context.install_root_dir}",
+                # make the package coinstallable                
+                "--define",
+                "_build_id_links none",
                 "-bb",
                 "package.spec",
             ],

--- a/ldnp/rpm.py
+++ b/ldnp/rpm.py
@@ -122,7 +122,7 @@ class RpmPackager(AbstractPackager):
                 # better use a custom variable to make things explicit
                 "--define",
                 f"_install_root {self.context.install_root_dir}",
-                # make the package coinstallable                
+                # make the package coinstallable
                 "--define",
                 "_build_id_links none",
                 "-bb",


### PR DESCRIPTION
This change enables us to provide multiple rpm's that ship identical elf files.

https://github.com/owncloud/client/issues/11206