### PR TITLE
Keep upload and download artifacts actions versions up to date

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -10,7 +10,7 @@ jobs:
     name: Quality Assurance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           sudo apt-get install python3.11 python3.11-dev libgpgme-dev
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install -y rpm wget git build-essential swig file
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build AppImage
         run: |
           git config --global --add safe.directory '*'
@@ -37,7 +37,7 @@ jobs:
           # see https://github.com/conda/conda/issues/12250
           ./appimagecraft-x86_64.AppImage -d /tmp/build
       - name: Archive artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: AppImage
           path: linuxdeploy-plugin-native_packages*.AppImage*
@@ -52,7 +52,7 @@ jobs:
       - build-appimage
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
       - name: Inspect directory after downloading artifacts
         run: ls -alFR
       - name: Create release and upload artifacts


### PR DESCRIPTION
Hi!

First of all, thank you so much for your hard work on the `linuxdeploy` project. I use it extensively in my CI builds to generate releases for my Linux users, and it's been a real time-saver (especially with Qt 6 apps).

Today, I came across this repository and wanted to give it a try. Many of my users have requested that I provide Debian and RPM packages, and I believe the solution implemented by this plugin is exactly what I need. So far, I've successfully built a functional `*.deb` package in my CI pipeline, and I'm still working on getting `*.rpm` packages to build properly.

While testing, I forked the repository to add some debug logging to help troubleshoot an issue. During the process, I encountered a failure in the CI workflow due to the use of deprecated versions of the upload and download artifact actions. More details on this deprecation can be found [here](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/). 

To resolve the issue, I updated the actions to their latest version (`v4`), which fixed the problem and allowed the workflow to pass successfully. Hope you find this fix useful.

Thanks again for all your work on this project!

-- Alex Spataru